### PR TITLE
Justine dev : namespace + circular includes fix

### DIFF
--- a/Engine/Collider.cpp
+++ b/Engine/Collider.cpp
@@ -1,0 +1,11 @@
+#include "Collider.h"
+
+Collider::Collider()
+{
+
+}
+
+Collider::~Collider()
+{
+
+}

--- a/Engine/Collider.cpp
+++ b/Engine/Collider.cpp
@@ -1,7 +1,9 @@
 #include "Collider.h"
+#include "GameObject.h"
 
+using namespace DirectX;
 
-Collider::Collider()
+Collider::Collider(GameObject* gameObject) : Component(gameObject)
 {
 
 }
@@ -30,9 +32,9 @@ float Collider::GetDistance(const GameObject& Gameobject2)
 	return mDistance;
 }
 
-bool Collider::IsColliding(GameObject* mGameObjectPtr, const GameObject& Gameobject2)
-{
-	//if (mGameObjectPtr.mCmps);
-
-
-}
+//bool Collider::IsColliding(GameObject* mGameObjectPtr, const GameObject& Gameobject2)
+//{
+//	//if (mGameObjectPtr.mCmps);
+//
+//
+//}

--- a/Engine/Collider.cpp
+++ b/Engine/Collider.cpp
@@ -1,5 +1,6 @@
 #include "Collider.h"
 
+
 Collider::Collider()
 {
 
@@ -7,5 +8,31 @@ Collider::Collider()
 
 Collider::~Collider()
 {
+
+}
+
+float Collider::GetDistance(const GameObject& Gameobject2)
+{
+	float mDistance;
+	XMFLOAT3 mCenter2; 
+	mCenter.x = mGameObjectPtr->mTransform.vPosition.x;
+	mCenter.y = mGameObjectPtr->mTransform.vPosition.y;
+	mCenter.z = mGameObjectPtr->mTransform.vPosition.z;
+
+	mCenter2.x = Gameobject2.mTransform.vPosition.x;
+	mCenter2.y = Gameobject2.mTransform.vPosition.y;
+	mCenter2.z = Gameobject2.mTransform.vPosition.z;
+	
+	mDistance = sqrtf(((mCenter.x - mCenter2.x) * (mCenter.x - mCenter2.x)) +
+		((mCenter.y - mCenter2.y) * (mCenter.y - mCenter2.y)) +
+		((mCenter.z - mCenter2.z) * (mCenter.z - mCenter2.z)));
+
+	return mDistance;
+}
+
+bool Collider::IsColliding(GameObject* mGameObjectPtr, const GameObject& Gameobject2)
+{
+	//if (mGameObjectPtr.mCmps);
+
 
 }

--- a/Engine/Collider.h
+++ b/Engine/Collider.h
@@ -1,23 +1,17 @@
 #pragma once
+#include <DirectXMath.h>
+#include "GameObject.h"
 
-struct coordinate {
-	int x;
-	int y;
-	int z;
-};
-
-class Collider
+class Collider : public Component
 {
-	struct coordinate {
-		int x;
-		int y;
-		int z;
-	};
+private:
+	XMFLOAT3 mScale;
+	
 public:
+	XMFLOAT3 mCenter;
+	XMFLOAT3 mRadius;
 	Collider();
 	~Collider();
-private:
-	int mSize;
-	int mCenter;
-};
-
+	float GetDistance(const GameObject& Gameobject2);
+	bool IsColliding(GameObject* mGameObjectPtr, const GameObject& Gameobject2);
+}; 

--- a/Engine/Collider.h
+++ b/Engine/Collider.h
@@ -1,17 +1,20 @@
 #pragma once
 #include <DirectXMath.h>
-#include "GameObject.h"
+//#include "GameObject.h"
+#include "Component.h"
+
+class GameObject;
 
 class Collider : public Component
 {
 private:
-	XMFLOAT3 mScale;
+	DirectX::XMFLOAT3 mScale;
 	
 public:
-	XMFLOAT3 mCenter;
-	XMFLOAT3 mRadius;
-	Collider();
+	DirectX::XMFLOAT3 mCenter;
+	DirectX::XMFLOAT3 mRadius;
+	Collider(GameObject* gameObject);
 	~Collider();
 	float GetDistance(const GameObject& Gameobject2);
-	bool IsColliding(GameObject* mGameObjectPtr, const GameObject& Gameobject2);
+	//bool IsColliding(GameObject* mGameObjectPtr, const GameObject& Gameobject2);
 }; 

--- a/Engine/Collider.h
+++ b/Engine/Collider.h
@@ -1,0 +1,23 @@
+#pragma once
+
+struct coordinate {
+	int x;
+	int y;
+	int z;
+};
+
+class Collider
+{
+	struct coordinate {
+		int x;
+		int y;
+		int z;
+	};
+public:
+	Collider();
+	~Collider();
+private:
+	int mSize;
+	int mCenter;
+};
+

--- a/Engine/Component.cpp
+++ b/Engine/Component.cpp
@@ -4,3 +4,8 @@ Component::Component()
 {
 
 }
+
+Component::~Component()
+{
+
+}

--- a/Engine/Component.cpp
+++ b/Engine/Component.cpp
@@ -1,4 +1,5 @@
 #include "Component.h"
+#include "GameObject.h"
 
 Component::Component(GameObject* gameObject)
 {

--- a/Engine/Component.cpp
+++ b/Engine/Component.cpp
@@ -1,8 +1,8 @@
 #include "Component.h"
 
-Component::Component()
+Component::Component(GameObject* gameObject)
 {
-
+    mGameObjectPtr = gameObject;
 }
 
 Component::~Component()

--- a/Engine/Component.h
+++ b/Engine/Component.h
@@ -5,12 +5,10 @@
 
 class Component
 {
-private:
-	Mesh mMesh;
-	Collider mCollider;
-	Rigidbody mRigidbody;
+protected:
+	GameObject* mGameObjectPtr;
 public:
-	Component();
+	Component(GameObject* gameObject);
 	~Component();
 };
 

--- a/Engine/Component.h
+++ b/Engine/Component.h
@@ -1,18 +1,23 @@
 #pragma once
-#include "Mesh.h"
-#include "Collider.h"
-#include "Rigidbody.h"
+
+//#include "GameObject.h"
 
 class GameObject;
 
 class Component
 {
-protected:
-	GameObject* mGameObjectPtr;
 public:
 	Component(GameObject* gameObject);
 	~Component();
 
-private:
+	enum Type
+	{
+		COLLIDER,
+		RIGIDBODY,
+		MESH,
+		TRIGGER
+	};
+
+protected:
 	GameObject* mGameObjectPtr;
 };

--- a/Engine/Component.h
+++ b/Engine/Component.h
@@ -1,6 +1,14 @@
 #pragma once
+#include "Mesh.h"
+#include "Collider.h"
+#include "Rigidbody.h"
+
 class Component
 {
+private:
+	Mesh mMesh;
+	Collider mCollider;
+	Rigidbody mRigidbody;
 public:
 	Component();
 	~Component();

--- a/Engine/Engine.cpp
+++ b/Engine/Engine.cpp
@@ -1,7 +1,9 @@
 #include "Engine.h"
 #include <sstream>
 
+using namespace Microsoft::WRL;
 using namespace DirectX;
+using namespace std;
 
 Engine::Engine(HWND hWnd) : mHWnd(hWnd), input(hWnd)
 {

--- a/Engine/Engine.h
+++ b/Engine/Engine.h
@@ -15,13 +15,9 @@
 #include "Input.h"
 #include "GeometryGenerator.h"
 
-using namespace Microsoft::WRL;
-using namespace DirectX;
-using namespace std;
-
 struct ObjectConstants
 {
-    XMFLOAT4X4 WorldViewProj = MathHelper::Identity4x4();
+    DirectX::XMFLOAT4X4 WorldViewProj = MathHelper::Identity4x4();
 };
 
 class Engine
@@ -80,47 +76,48 @@ private:
 
     static const int mSwapChainBufferCount = 2;
 
-    unique_ptr<UploadBuffer<ObjectConstants>> mObjectCB = nullptr;
+    std::unique_ptr<UploadBuffer<ObjectConstants>> mObjectCB = nullptr;
 
-    ComPtr<ID3D12Fence> mFence;
-    ComPtr<ID3D12CommandAllocator> mCommandAllocator;
-    ComPtr<ID3D12CommandQueue> mCommandQueue;
-    ComPtr<ID3D12GraphicsCommandList> mCommandList;
-    ComPtr<ID3D12Device> mD3DDevice;
-    ComPtr<IDXGISwapChain> mSwapChain;
-    ComPtr<IDXGIFactory4> mDxgiFactory;
-    ComPtr<ID3D12DescriptorHeap> mRtvHeap;
-    ComPtr<ID3D12DescriptorHeap> mDsvHeap;
-    ComPtr<ID3D12DescriptorHeap> mCbvHeap;
-    ComPtr<ID3D12Resource> mSwapChainBuffer[mSwapChainBufferCount];
-    ComPtr<ID3D12Resource> mDepthStencilBuffer;
-    ComPtr<ID3D12PipelineState> mPSO = nullptr;
-    ComPtr<ID3D12RootSignature> mRootSignature = nullptr;
-    ComPtr<ID3DBlob> mVsByteCode = nullptr;
-    ComPtr<ID3DBlob> mPsByteCode = nullptr;
+    Microsoft::WRL::ComPtr<ID3D12Fence> mFence;
+    Microsoft::WRL::ComPtr<ID3D12CommandAllocator> mCommandAllocator;
+    Microsoft::WRL::ComPtr<ID3D12CommandQueue> mCommandQueue;
+    Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> mCommandList;
+    Microsoft::WRL::ComPtr<ID3D12Device> mD3DDevice;
+    Microsoft::WRL::ComPtr<IDXGISwapChain> mSwapChain;
+    Microsoft::WRL::ComPtr<IDXGIFactory4> mDxgiFactory;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mRtvHeap;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mDsvHeap;
+    Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> mCbvHeap;
+    Microsoft::WRL::ComPtr<ID3D12Resource> mSwapChainBuffer[mSwapChainBufferCount];
+    Microsoft::WRL::ComPtr<ID3D12Resource> mDepthStencilBuffer;
+    Microsoft::WRL::ComPtr<ID3D12PipelineState> mPSO = nullptr;
+    Microsoft::WRL::ComPtr<ID3D12RootSignature> mRootSignature = nullptr;
+    Microsoft::WRL::ComPtr<ID3DBlob> mVsByteCode = nullptr;
+    Microsoft::WRL::ComPtr<ID3DBlob> mPsByteCode = nullptr;
 
     UINT64 mCurrentFence = 0;
 
     D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS msQualityLevels;
 
-    vector<D3D12_INPUT_ELEMENT_DESC> mInputLayout;
+    std::vector<D3D12_INPUT_ELEMENT_DESC> mInputLayout;
 
     D3D12_VIEWPORT mViewport;
     D3D12_RECT mScissorRect;
 
-    unique_ptr<MeshGeometry> mTriangleGeo = nullptr;
+    std::unique_ptr<MeshGeometry> mTriangleGeo = nullptr;
 
     DXGI_FORMAT mBackBufferFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
     DXGI_FORMAT mDepthStencilFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
 
-    XMFLOAT4X4 mWorld = MathHelper::Identity4x4();
-    XMFLOAT4X4 mView = MathHelper::Identity4x4();
-    XMFLOAT4X4 mProj = MathHelper::Identity4x4();
+    DirectX::XMFLOAT4X4 mWorld = MathHelper::Identity4x4();
+    DirectX::XMFLOAT4X4 mView = MathHelper::Identity4x4();
+    DirectX::XMFLOAT4X4 mProj = MathHelper::Identity4x4();
+
+    float mTheta = 1.5f * DirectX::XM_PI;
+    float mPhi = DirectX::XM_PIDIV4;
+    float mRadius = 5.0f;
 
     Input input;
-    float mTheta = 1.5f * XM_PI;
-    float mPhi = XM_PIDIV4;
-    float mRadius = 5.0f;
 
     int mClientWidth = 800;
     int mClientHeight = 600;

--- a/Engine/Engine.vcxproj
+++ b/Engine/Engine.vcxproj
@@ -89,6 +89,7 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Collider.cpp" />
     <ClCompile Include="Component.cpp" />
     <ClCompile Include="d3dUtil.cpp" />
     <ClCompile Include="DDSTextureLoader.cpp" />
@@ -98,10 +99,13 @@
     <ClCompile Include="MathHelper.cpp" />
     <ClCompile Include="Input.cpp" />
     <ClCompile Include="GameTimer.cpp" />
+    <ClCompile Include="Mesh.cpp" />
+    <ClCompile Include="Rigidbody.cpp" />
     <ClCompile Include="ShaderManager.cpp" />
     <ClCompile Include="Transform.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Collider.h" />
     <ClInclude Include="Component.h" />
     <ClInclude Include="d3dUtil.h" />
     <ClInclude Include="d3dx12.h" />
@@ -112,6 +116,8 @@
     <ClInclude Include="MathHelper.h" />
     <ClInclude Include="Input.h" />
     <ClInclude Include="GameTimer.h" />
+    <ClInclude Include="Mesh.h" />
+    <ClInclude Include="Rigidbody.h" />
     <ClInclude Include="ShaderManager.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Engine/Engine.vcxproj.filters
+++ b/Engine/Engine.vcxproj.filters
@@ -39,6 +39,24 @@
     <ClCompile Include="ShaderManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Component.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="GameObject.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Manager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Mesh.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Collider.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Rigidbody.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="d3dUtil.h">
@@ -69,6 +87,24 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Transform.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Component.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="GameObject.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Manager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Mesh.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Collider.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Rigidbody.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Engine/GameObject.cpp
+++ b/Engine/GameObject.cpp
@@ -5,6 +5,11 @@ GameObject::GameObject()
 
 }
 
+GameObject::~GameObject()
+{
+
+}
+
 void GameObject::AddComponent(Component component)
 {
 	mCmps.push_back(component);

--- a/Engine/GameObject.cpp
+++ b/Engine/GameObject.cpp
@@ -10,8 +10,26 @@ GameObject::~GameObject()
 
 }
 
-void GameObject::AddComponent(Component component)
+void GameObject::AddCollider(Collider collider)
 {
-	mCmps.push_back(component);
+	mCmps.emplace(COLLIDER, collider);
 
 }
+
+void GameObject::AddRigidbody(Rigidbody rigidbody)
+{
+	mCmps.emplace(RIGIDBODY, rigidbody);
+
+}
+
+void GameObject::AddMesh(Mesh mesh)
+{
+	mCmps.emplace(MESH, mesh);
+
+}
+/*
+void GameObject::AddTrigger(Trigger trigger)
+{
+	mCmps.emplace(TRIGGER, trigger);
+
+}*/

--- a/Engine/GameObject.cpp
+++ b/Engine/GameObject.cpp
@@ -33,3 +33,13 @@ void GameObject::AddTrigger(Trigger trigger)
 	mCmps.emplace(TRIGGER, trigger);
 
 }*/
+
+void GameObject::Render()
+{
+
+}
+
+void GameObject::update()
+{
+
+}

--- a/Engine/GameObject.cpp
+++ b/Engine/GameObject.cpp
@@ -1,4 +1,5 @@
 #include "GameObject.h"
+//#include "Collider.h"
 
 GameObject::GameObject()
 {
@@ -12,21 +13,19 @@ GameObject::~GameObject()
 
 void GameObject::AddCollider(Collider collider)
 {
-	mCmps.emplace(COLLIDER, collider);
+	mCmps.emplace(Component::COLLIDER, collider);
 
 }
 
 void GameObject::AddRigidbody(Rigidbody rigidbody)
 {
-	mCmps.emplace(RIGIDBODY, rigidbody);
-
+	mCmps.emplace(Component::RIGIDBODY, rigidbody);
 }
 
-void GameObject::AddMesh(Mesh mesh)
-{
-	mCmps.emplace(MESH, mesh);
-
-}
+//void GameObject::AddMesh(Mesh mesh)
+//{
+//	mCmps.emplace(Component::MESH, mesh);
+//}
 /*
 void GameObject::AddTrigger(Trigger trigger)
 {

--- a/Engine/GameObject.h
+++ b/Engine/GameObject.h
@@ -1,26 +1,18 @@
 #pragma once
 
 #include <iostream>
-#include <vector>
-#include "Component.h"
-#include "MeshRenderer.h"
+#include <unordered_map>
 #include "Transform.h"
-
-using namespace std;
-
-enum ComponentType
-{
-	COLLIDER,
-	RIGIDBODY,
-	MESH,
-	TRIGGER
-};
+//#include "Component.h"
+#include "Collider.h"
+#include "Rigidbody.h" 
+#include "Mesh.h" 
 
 class GameObject
 {
 private:
-	string mName;
-	unordered_map<ComponentType,Component>mCmps;
+	std::string mName;
+	std::unordered_map<Component::Type, Component> mCmps;
 public:
 	Transform mTransform;
 	GameObject();
@@ -29,12 +21,6 @@ public:
 	void update();
 	void AddCollider(Collider collider);
 	void AddRigidbody(Rigidbody rigidbody);
-	void AddMesh(Mesh mesh);
+	//void AddMesh(Mesh mesh);
 	//void AddTrigger(Trigger trigger);
-};
-
-private:
-	string mName;
-	Transform mTransform;
-	vector<Component> mCmps;
 };

--- a/Engine/GameObject.h
+++ b/Engine/GameObject.h
@@ -6,15 +6,26 @@
 
 using namespace std;
 
+enum ComponentType
+{
+	COLLIDER,
+	RIGIDBODY,
+	MESH,
+	TRIGGER
+};
+
 class GameObject
 {
 private:
 	string mName;
-	Transform mTransform;
-	vector<Component>mCmps;
+	unordered_map<ComponentType,Component>mCmps;
 public:
+	Transform mTransform;
 	GameObject();
 	~GameObject();
-	void AddComponent(Component component);
+	void AddCollider(Collider collider);
+	void AddRigidbody(Rigidbody rigidbody);
+	void AddMesh(Mesh mesh);
+	//void AddTrigger(Trigger trigger);
 };
 

--- a/Engine/GameObject.h
+++ b/Engine/GameObject.h
@@ -23,6 +23,8 @@ public:
 	Transform mTransform;
 	GameObject();
 	~GameObject();
+	void Render();
+	void update();
 	void AddCollider(Collider collider);
 	void AddRigidbody(Rigidbody rigidbody);
 	void AddMesh(Mesh mesh);

--- a/Engine/Mesh.cpp
+++ b/Engine/Mesh.cpp
@@ -1,0 +1,1 @@
+#include "Mesh.h"

--- a/Engine/Mesh.h
+++ b/Engine/Mesh.h
@@ -1,0 +1,6 @@
+#pragma once
+
+class Mesh
+{
+};
+

--- a/Engine/Rigidbody.cpp
+++ b/Engine/Rigidbody.cpp
@@ -1,0 +1,1 @@
+#include "Rigidbody.h"

--- a/Engine/Rigidbody.cpp
+++ b/Engine/Rigidbody.cpp
@@ -1,1 +1,6 @@
 #include "Rigidbody.h"
+#include "GameObject.h"
+
+Rigidbody::Rigidbody(GameObject* gameObject) : Component(gameObject)
+{
+}

--- a/Engine/Rigidbody.h
+++ b/Engine/Rigidbody.h
@@ -1,0 +1,5 @@
+#pragma once
+class Rigidbody
+{
+};
+

--- a/Engine/Rigidbody.h
+++ b/Engine/Rigidbody.h
@@ -1,5 +1,11 @@
 #pragma once
-class Rigidbody
+#include "Component.h"
+
+class GameObject;
+
+class Rigidbody : public Component
 {
+public:
+	Rigidbody(GameObject* gameObject);;
 };
 

--- a/Engine/ShaderManager.cpp
+++ b/Engine/ShaderManager.cpp
@@ -1,5 +1,8 @@
 #include "ShaderManager.h"
 
+using namespace std;
+using namespace Microsoft::WRL;
+
 ShaderManager::ShaderManager()
 {
    

--- a/Engine/ShaderManager.h
+++ b/Engine/ShaderManager.h
@@ -2,12 +2,9 @@
 
 #include "d3dUtil.h"
 
-using namespace std;
-using namespace Microsoft::WRL;
-
 struct ByteCode {
-	ComPtr<ID3DBlob> vsCubeByteCode;
-	ComPtr<ID3DBlob> psCubeByteCode;
+	Microsoft::WRL::ComPtr<ID3DBlob> vsCubeByteCode;
+	Microsoft::WRL::ComPtr<ID3DBlob> psCubeByteCode;
 };
 
 class ShaderManager
@@ -18,7 +15,7 @@ public:
 
 	ByteCode CallStack();
 
-	ComPtr<ID3DBlob> CompileShader(wstring shaderFile, string entryPoint, string target);
+	Microsoft::WRL::ComPtr<ID3DBlob> CompileShader(std::wstring shaderFile, std::string entryPoint, std::string target);
 private:
 	
 };

--- a/Engine/Transform.cpp
+++ b/Engine/Transform.cpp
@@ -1,5 +1,7 @@
 #include "Transform.h"
 
+using namespace DirectX;
+
 Transform::Transform() : vPosition(0.0f, 0.0f, 0.0f), vScale(1.0f, 1.0f, 1.0f)
 {
     // Constructor: Initialize the transformation with default values

--- a/Engine/Transform.h
+++ b/Engine/Transform.h
@@ -1,30 +1,29 @@
 #pragma once
-#include "Engine.h"
 #include <DirectXMath.h>
 
 class Transform
 {
 public:
-    XMFLOAT3 vPosition; // Translation vector for the object
-    XMFLOAT4X4 mPosition; // Transformation matrix for translation
+    DirectX::XMFLOAT3 vPosition; // Translation vector for the object
+    DirectX::XMFLOAT4X4 mPosition; // Transformation matrix for translation
     
-    XMFLOAT3 vScale; // Scale factors along the x, y, and z axes
-    XMFLOAT4X4 mScale; // Transformation matrix for scaling
+    DirectX::XMFLOAT3 vScale; // Scale factors along the x, y, and z axes
+    DirectX::XMFLOAT4X4 mScale; // Transformation matrix for scaling
     
-    XMFLOAT4 qRotation; // Quaternion representing rotation
-    XMFLOAT4X4 mRotation; // Transformation matrix for rotation
+    DirectX::XMFLOAT4 qRotation; // Quaternion representing rotation
+    DirectX::XMFLOAT4X4 mRotation; // Transformation matrix for rotation
     
-    XMFLOAT3 vForward; // Forward vector in local space
-    XMFLOAT3 vRight; // Right vector in local space
-    XMFLOAT3 vUp; // Up vector in local space
+    DirectX::XMFLOAT3 vForward; // Forward vector in local space
+    DirectX::XMFLOAT3 vRight; // Right vector in local space
+    DirectX::XMFLOAT3 vUp; // Up vector in local space
     
-    XMFLOAT4X4 mWorldMatrix; // Combined transformation matrix for the world
+    DirectX::XMFLOAT4X4 mWorldMatrix; // Combined transformation matrix for the world
     
     Transform(); // Constructor for the Transform class
    
 
     void InitializeIdentity();  // Initialize transformation matrices as identity matrices
-    void FromMatrix(XMMATRIX* pMat);  // Decompose and update transformation from a given matrix
+    void FromMatrix(DirectX::XMMATRIX* pMat);  // Decompose and update transformation from a given matrix
 
     void UpdateRotationFromVectors();  // Update rotation from the forward, right, and up vectors
     void UpdateRotationFromQuaternion();  // Not implemented in this code


### PR DESCRIPTION
- removed using namespace from header files
- fixed circular include between GameObject, Component and inherited class from Component